### PR TITLE
Adding rails-api-newrelic

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -124,3 +124,6 @@
 [submodule "prun-ops"]
 	path = prun-ops
 	url = git@github.com:jlebrijo/prun-ops
+[submodule "rails-api-newrelic"]
+	path = rails-api-newrelic
+	url = https://github.com/covermymeds/rails-api-newrelic


### PR DESCRIPTION
This pull request pulls in rails-api-newrelic, which should instrument code based on the rails-api gem irrespective of whether it is based on rails3 or rails4.  This is a gem from a third party (covermymeds isn't my account), but seems to work okay.
